### PR TITLE
check if the error on netrc occurs because the file does not exist

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"github.com/nicolasdscp/giwow/internal/netrc"
+
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +25,12 @@ func init() {
 }
 
 func persistentPreRunEToken(cmd *cobra.Command, _ []string) error {
-	return netrc.ResolveCurrent(cmd.Flag("netrc").Value.String())
+	err := netrc.ResolveCurrent(cmd.Flag("netrc").Value.String())
+	if os.IsNotExist(err) {
+		os.Exit(1)
+	}
+
+	return err
 }
 
 func runTokenE(cmd *cobra.Command, args []string) error {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"github.com/nicolasdscp/giwow/internal/exception"
 	"github.com/nicolasdscp/giwow/internal/netrc"
+	"github.com/nicolasdscp/giwow/logger"
 
 	"os"
 
@@ -27,7 +29,7 @@ func init() {
 func persistentPreRunEToken(cmd *cobra.Command, _ []string) error {
 	err := netrc.ResolveCurrent(cmd.Flag("netrc").Value.String())
 	if os.IsNotExist(err) {
-		os.Exit(1)
+		logger.Fatal(exception.ErrNetrcFileNotExist(err).Error())
 	}
 
 	return err

--- a/internal/exception/workspace.go
+++ b/internal/exception/workspace.go
@@ -16,3 +16,8 @@ func ErrWorkspaceNotFound() error {
 func ErrProjectAlreadyExists() error {
 	return fmt.Errorf("project already exists in this workspace")
 }
+
+// ErrNetrcFileNotExist is triggered when the netrc file does not exist.
+func ErrNetrcFileNotExist(err error) error {
+	return fmt.Errorf("netrc file does not exist: %w", err)
+}

--- a/internal/netrc/netrc.go
+++ b/internal/netrc/netrc.go
@@ -53,7 +53,6 @@ func ResolveCurrent(netrcPath string) (netrcErr error) {
 
 	stat, err := os.Stat(netrcPath)
 	if err != nil || stat.IsDir() {
-		logger.Print("Could not find netrc file at %s", netrcPath)
 		return err
 	}
 


### PR DESCRIPTION
when doing `giwow token ls` with no netrc file

instead of having a terminal return such as
```
> Could not find netrc file at /Users/usr/.netrc
Error: stat /Users/usr/.netrc: no such file or directory
Usage:
  giwow token ls [flags]

Flags:
  -h, --help       help for ls
  -m, --magnify    Print tokens in a magnified array format
      --showPass   Display your tokens passwords

Global Flags:
      --debug          Enable debug and verbose messages, use in development only
      --netrc string   The path to the netrc file, default is $HOME/.netrc
      --verbose        Enable verbose messages

panic: stat /Users/usr/.netrc: no such file or directory

goroutine 1 [running]:
main.main()
        /Users/usr/go/src/github.com/nicolasdscp/giwow/main.go:7 +0x50
```

it will print 

``` 
> Could not find netrc file at /Users/usr/.netrc
Exiting.
```